### PR TITLE
reformat output of `compute_surface_dice_from_images`

### DIFF
--- a/examples/BraTS/metrics/project/app.py
+++ b/examples/BraTS/metrics/project/app.py
@@ -84,7 +84,12 @@ def score(parent, preds_dir, tmp_output="tmp.csv") -> pd.DataFrame:
                 normalized_surface_dice = compute_surface_dice_from_images(
                     pred, gold, tolerance=1.0
                 )
-                scan_scores.update(normalized_surface_dice)
+                normalized_df = (pd.DataFrame
+                                 .from_dict(normalized_surface_dice, orient='index')
+                                 .transpose()
+                                 .rename(index={0: subject_id})
+                                 )
+                scan_scores = scan_scores.join(normalized_df)
             except subprocess.CalledProcessError:
                 # If no output found, give penalized scores.
                 scan_scores = pd.DataFrame(


### PR DESCRIPTION
## Bug

The current output of `compute_surface_dice_from_images` is a dict, which cannot be merged with a df, e.g.

```python
>>> normalized_surface_dice = compute_surface_dice_from_images(
...     pred, gold, tolerance=1.0
... )
>>> normalized_surface_dice
{'NormalizedSurfaceDice_TC': 0.999999995, 'NormalizedSurfaceDice_ET': 0.999999995, 'NormalizedSurfaceDice_WT': 0.999999995}
>>> scan_scores.update(normalized_surface_dice)
Traceback (most recent call last):
  File "/Users/vchung/opt/miniconda3/envs/test/lib/python3.10/site-packages/pandas/core/frame.py", line 8235, in update
    other = DataFrame(other)
  File "/Users/vchung/opt/miniconda3/envs/test/lib/python3.10/site-packages/pandas/core/frame.py", line 664, in __init__
    mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy, typ=manager)
  File "/Users/vchung/opt/miniconda3/envs/test/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 493, in dict_to_mgr
    return arrays_to_mgr(arrays, columns, index, dtype=dtype, typ=typ, consolidate=copy)
  File "/Users/vchung/opt/miniconda3/envs/test/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 118, in arrays_to_mgr
    index = _extract_index(arrays)
  File "/Users/vchung/opt/miniconda3/envs/test/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 656, in _extract_index
    raise ValueError("If using all scalar values, you must pass an index")
ValueError: If using all scalar values, you must pass an index
```

## Proposed fix

Convert the output to a df, where the index is the `subject_id`, so that we can more easily merge the two dfs together, e.g.

```python
>>> res = pd.DataFrame.from_dict(normalized_surface_dice, orient='index').transpose().rename(index={0: subject_id})
>>> res
                 NormalizedSurfaceDice_TC  NormalizedSurfaceDice_ET  NormalizedSurfaceDice_WT
BraTS2021_00027                       1.0                       1.0                       1.0
>>> 
>>> scan_scores.join(res)
                 Dice_ET  Dice_TC  Dice_WT  Hausdorff95_ET  Hausdorff95_TC  Hausdorff95_WT  Sensitivity_ET  Sensitivity_TC  Sensitivity_WT  Specificity_ET  Specificity_TC  Specificity_WT  Precision_ET  Precision_TC  Precision_WT  NormalizedSurfaceDice_TC  NormalizedSurfaceDice_ET  NormalizedSurfaceDice_WT
subject_id                                                                                                                                                                                                                                                                                                        
BraTS2021_00027      1.0      1.0      1.0             0.0             0.0             0.0             1.0             1.0             1.0             1.0             1.0             1.0           1.0           1.0           1.0                       1.0                       1.0                       1.0
```

I tested this change (in Python3.10) and it works as expected 🥳 :

```
$ python app.py --preds_dir ~/Downloads/test_data/ \
  --data_path ~/Downloads/test_data/ \
  --output_file results.yaml
$ cat results.yaml
BraTS2021_00027:
  Dice_ET: 1.0
  Dice_TC: 1.0
  Dice_WT: 1.0
  Hausdorff95_ET: 0.0
  Hausdorff95_TC: 0.0
  Hausdorff95_WT: 0.0
  NormalizedSurfaceDice_ET: 0.999999995
  NormalizedSurfaceDice_TC: 0.999999995
  NormalizedSurfaceDice_WT: 0.999999995
  Precision_ET: 1.0
  Precision_TC: 1.0
  Precision_WT: 1.0
  Sensitivity_ET: 1.0
  Sensitivity_TC: 1.0
  Sensitivity_WT: 1.0
  Specificity_ET: 1.0
  Specificity_TC: 1.0
  Specificity_WT: 1.0
```